### PR TITLE
Fix temp table issues

### DIFF
--- a/fast_to_sql/fast_to_sql.py
+++ b/fast_to_sql/fast_to_sql.py
@@ -76,7 +76,7 @@ def _get_schema(cur: pyodbc.Cursor, table_name: str):
 def _clean_table_name(table_name, temp):
     """Cleans the table name
     """
-    if temp == True and table_name.find('#') == True:
+    if temp == True and table_name.find('#') != 0:
         return '#'+table_name.replace("'","''")
     else:
         return table_name.replace("'","''")

--- a/fast_to_sql/fast_to_sql.py
+++ b/fast_to_sql/fast_to_sql.py
@@ -21,8 +21,8 @@ def _check_duplicate_cols(df):
     cols = [c.lower() for c in df.columns]
     dups = [x for x in cols if cols.count(x) > 1]
     if dups:
-        raise errors.DuplicateColumns(f"There are duplicate column names. Repeated names are: {dups}.",
-                                      "SQL Server dialect requires unique names (case insensitive).")
+        raise errors.DuplicateColumns((f"There are duplicate column names. Repeated names are: {dups}."
+                                      "SQL Server dialect requires unique names (case insensitive)."))
 
 def _clean_col_name(column):
     """Removes special characters from column names

--- a/fast_to_sql/fast_to_sql.py
+++ b/fast_to_sql/fast_to_sql.py
@@ -21,8 +21,7 @@ def _check_duplicate_cols(df):
     cols = [c.lower() for c in df.columns]
     dups = [x for x in cols if cols.count(x) > 1]
     if dups:
-        raise errors.DuplicateColumns((f"There are duplicate column names. Repeated names are: {dups}."
-                                      "SQL Server dialect requires unique names (case insensitive)."))
+        raise errors.DuplicateColumns(f"There are duplicate column names. Repeated names are: {dups}. SQL Server dialect requires unique names (case insensitive).")
 
 def _clean_col_name(column):
     """Removes special characters from column names
@@ -152,10 +151,7 @@ def fast_to_sql(df, name, conn, if_exists='append', custom=None, temp=False, cop
             create_statement = _generate_create_statement(schema, name, data_types, temp)
             cur.execute(create_statement)
         elif if_exists == "fail":
-            if temp:
-                fail_msg = f"Temp table [{name}] already exists in this connection"
-            else:
-                fail_msg = f"Table [{schema}].[{name}] already exists" 
+            fail_msg = f"Temp table [{name}] already exists in this connection" if temp else f"Table [{schema}].[{name}] already exists" 
             raise errors.FailError(fail_msg)
     else:
         create_statement = _generate_create_statement(schema, name, data_types, temp)

--- a/fast_to_sql/fast_to_sql.py
+++ b/fast_to_sql/fast_to_sql.py
@@ -8,9 +8,12 @@ from . import errors
 
 # Global
 DTYPE_MAP = {
-    "int64": "int",
+    "int64": "bigint",
+    "int32": "int",
+    "int16": "smallint",
+    "int8": "tinyint",
     "float64": "float",
-    "object": "varchar(255)",
+    "object": "nvarchar(255)",
     "datetime64[ns]": "datetime2",
     "bool": "bit"
 }


### PR DESCRIPTION
Currently, fast_to_sql has some limitations when working with temp tables:

1. no support for creating global temp tables ##
2. if_exists = 'replace' does not drop a temp table as expected

This pull request addresses these issues by modifying the helper function _clean_table_name so that, when temp == True it:

1. returns the valid table name if the input str begins with '#'
2. otherwise, prepends the table name with '#' 

With this fix in place, the cleaned table name can be used throughout the rest of the script obviating the need to hard code any  '#' into table names and avoiding the trouble that this method had caused for temp tables

Also added some additional data type support for additional numpy integer types in DTYPE_MAP