### PR TITLE
Update fast_to_sql.py

### DIFF
--- a/fast_to_sql/fast_to_sql.py
+++ b/fast_to_sql/fast_to_sql.py
@@ -166,7 +166,7 @@ def fast_to_sql(df, name, conn, if_exists='append', custom=None, temp=False, cop
     else:
         insert_sql = f"insert into [{schema}].[{name}] values ({','.join(['?' for v in data_types])})"
     insert_cols = df.values.tolist()
-    insert_cols = [[None if type(cell) == float and np.isnan(cell) else cell for cell in row] for row in insert_cols]
+    insert_cols = [[None if pd.isna(cell) else cell for cell in row] for row in insert_cols]
     cur.fast_executemany = True
     cur.executemany(insert_sql, insert_cols)
     cur.close()


### PR DESCRIPTION
This tiny change purpose is to deal with all NaN values as well as NaT values.

The previous code was not handling NaT values (equivalent of NaN values of datetime64) causing the code to break when handling those objects in df.

It is especially helping when a table is updated from a datetime2 dtype into a datetime dtype.